### PR TITLE
Add Dockerfile for cross-compiling ghost.exe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM dockcross/windows-static-x86
+
+WORKDIR /usr/src/app
+COPY . .
+
+# disable MySQL to avoid extra dependencies
+RUN sed -i 's/^DFLAGS = -DGHOST_MYSQL/DFLAGS =/' ghost++/ghost/Makefile && \
+    sed -i 's/-lmysqlclient_r //' ghost++/ghost/Makefile
+
+# build bncsutil library
+RUN /usr/local/bin/dockcross bash -c "cd ghost++/bncsutil/src/bncsutil && make"
+
+# build ghost executable
+RUN /usr/local/bin/dockcross bash -c "cd ghost++/ghost && make C++=\$CXX CC=\$CC"
+
+# copy final binary to /dist for easy volume mount
+RUN mkdir /dist && cp ghost++/ghost/ghost++.exe /dist/ghost.exe
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -89,3 +89,16 @@ We do not support OS X
 
 ##### The OHSystem was founded by Neubivljiv & Grief-Code.
 We have been working on the development process since over a year now and started the last months to include a full hosting platform which is constantly growing each day.
+
+## Building ghost.exe with Docker
+
+To cross-compile the Windows binary on macOS or Linux you can use the included `Dockerfile`. Build the image and mount a host directory to extract the result:
+
+```bash
+docker build -t ghost-builder .
+mkdir out
+docker run --rm -v "$(pwd)/out":/dist ghost-builder
+```
+
+The compiled `ghost.exe` will be placed inside the `out` directory on your host.
+


### PR DESCRIPTION
## Summary
- add Dockerfile using dockcross/windows-static-x86 for building ghost.exe
- document how to build the Windows binary with Docker

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684fd82630f48326af00d8e41efde31c