### PR TITLE
Remove GMP from bncsutil build

### DIFF
--- a/ghost++/bncsutil/src/bncsutil/Makefile
+++ b/ghost++/bncsutil/src/bncsutil/Makefile
@@ -7,16 +7,11 @@ CC = gcc
 CCFLAGS = -Wall -O3 -I ../ -Wno-multichar -fPIC
 CCOBJ = nls.o pe.o sha1.o stack.o
 
-ifeq ($(SYSTEM),Darwin)
-LDFLAGS = -dynamiclib -lgmp -L/opt/local/lib
-TARGET = libbncsutil.dylib
-else
-LDFLAGS = -shared -lgmp
 TARGET = libbncsutil.so
-endif
+OBJS = $(CXXOBJ) $(CCOBJ)
 
-$(TARGET): $(CXXOBJ) $(CCOBJ)
-	$(CXX)  $(CXXFLAGS) $(LDFLAGS) $(CXXOBJ) $(CCOBJ) -o $(TARGET)
+$(TARGET): $(OBJS)
+	$(CXX) $(CXXFLAGS) -shared $(OBJS) -o libbncsutil.so
 
 $(CXXOBJ): %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $< -o $@ 


### PR DESCRIPTION
## Summary
- remove GMP from `bncsutil` makefile
- set a single `TARGET` and `OBJS` variable
- compile the library with `-shared` without gmp

## Testing
- `make -C ghost++/bncsutil/src/bncsutil clean`
- `make -C ghost++/bncsutil/src/bncsutil`

------
https://chatgpt.com/codex/tasks/task_e_68501fad3f8c832680dce13b05b527cd