### PR TITLE
Fix MySQL header path for Windows build

### DIFF
--- a/ghost++/ghost/ghostdbmysql.cpp
+++ b/ghost++/ghost/ghostdbmysql.cpp
@@ -32,7 +32,7 @@
 #include <winsock.h>
 #endif
 
-#include <mysql/mysql.h>
+#include <mysql.h>
 #include <boost/thread.hpp>
 
 //

--- a/ghost++/update_dota_elo/update_dota_elo.cpp
+++ b/ghost++/update_dota_elo/update_dota_elo.cpp
@@ -43,7 +43,7 @@ using namespace std;
  #include <winsock.h>
 #endif
 
-#include <mysql/mysql.h>
+#include <mysql.h>
 
 void CONSOLE_Print( string message )
 {

--- a/ghost++/update_stats/update_stats.cpp
+++ b/ghost++/update_stats/update_stats.cpp
@@ -51,7 +51,7 @@ using namespace std;
  #include <winsock.h>
 #endif
 
-#include <mysql/mysql.h>
+#include <mysql.h>
 
 #include <stdio.h>
 

--- a/ghost++/update_w3mmd_elo/update_w3mmd_elo.cpp
+++ b/ghost++/update_w3mmd_elo/update_w3mmd_elo.cpp
@@ -43,7 +43,7 @@ using namespace std;
  #include <winsock.h>
 #endif
 
-#include <mysql/mysql.h>
+#include <mysql.h>
 
 void CONSOLE_Print( string message )
 {

--- a/ghost++/update_w3mmd_elo/update_w3mmd_elo_merge_players.cpp
+++ b/ghost++/update_w3mmd_elo/update_w3mmd_elo_merge_players.cpp
@@ -47,7 +47,7 @@ using namespace std;
  #include <winsock.h>
 #endif
 
-#include <mysql/mysql.h>
+#include <mysql.h>
 
 void CONSOLE_Print( string message )
 {


### PR DESCRIPTION
## Summary
- fix include path for MySQL headers

## Testing
- `make` *(fails: boost/thread.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685118caf1d8832699a73e9e5f535912