### PR TITLE
Fix Windows build flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN cd ghost++/ghost \
     && make \
     CC=x86_64-w64-mingw32-gcc \
     CXX=x86_64-w64-mingw32-g++ \
-    CXXFLAGS="-I../bncsutil/src -I../StormLib -I${MYSQL_INC}" \
-    LDFLAGS="-L../bncsutil/src -L${MYSQL_LIB} -lmysql"
+    CFLAGS="-I../bncsutil/src -I../StormLib -I${MYSQL_INC}" \
+    LFLAGS="-L../bncsutil/src -L${MYSQL_LIB} -lmysql"
 
 #############################
 # Stage 2: Export only the .exe


### PR DESCRIPTION
## Summary
- fix the container build by passing mysql flags via `CFLAGS` and `LFLAGS`

## Testing
- `docker build -t ghost-builder .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68511b95eb7c832684978ff22b42ee13