### PR TITLE
Fix Docker build missing dlltool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 # 2) Install Boost & unzip
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    wget unzip libboost-all-dev mingw-w64-tools \
+    wget unzip libboost-all-dev mingw-w64-tools binutils-mingw-w64-x86-64 \
     && rm -rf /var/lib/apt/lists/*
 
 # 3) Download the Windows Connector/C ZIP (32-bit) and unpack it,


### PR DESCRIPTION
## Summary
- add binutils-mingw-w64-x86-64 so docker build finds `x86_64-w64-mingw32-dlltool`

## Testing
- `docker build -t ghost-builder .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685126498bc88326876acb20cfb5430c