### PR TITLE
Fix mysql def path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN wget -O mysql-connector.zip \
     && rm mysql-connector.zip \
     && mv mysql-connector-c-6.1.11-win32 mysql-connector \
     && gendef mysql-connector/lib/libmysql.dll \
+    && mv libmysql.def mysql-connector/lib/libmysql.def \
     && x86_64-w64-mingw32-dlltool -d mysql-connector/lib/libmysql.def \
        -l mysql-connector/lib/libmysql.a -D mysql-connector/lib/libmysql.dll
 


### PR DESCRIPTION
## Summary
- ensure the generated libmysql.def file is placed with the DLL

## Testing
- `gendef mysql-connector/lib/libmysql.dll` (manual test)

------
https://chatgpt.com/codex/tasks/task_e_6851274d72548326a76d13146ec7235f