### PR TITLE
Fix MySQL cross‑linking failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 # 2) Install Boost & unzip
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    wget unzip libboost-all-dev mingw-w64-tools binutils-mingw-w64-x86-64 \
+    wget unzip libboost-all-dev mingw-w64-tools binutils-mingw-w64-i686 \
     && rm -rf /var/lib/apt/lists/*
 
 # 3) Download the Windows Connector/C ZIP (32-bit) and unpack it,
@@ -26,7 +26,7 @@ RUN wget -O mysql-connector.zip \
     && mv mysql-connector-c-6.1.11-win32 mysql-connector \
     && gendef mysql-connector/lib/libmysql.dll \
     && mv libmysql.def mysql-connector/lib/libmysql.def \
-    && x86_64-w64-mingw32-dlltool -d mysql-connector/lib/libmysql.def \
+    && i686-w64-mingw32-dlltool -d mysql-connector/lib/libmysql.def \
        -l mysql-connector/lib/libmysql.a -D mysql-connector/lib/libmysql.dll
 
 # 4) Expose where the connector lives
@@ -38,14 +38,14 @@ RUN sed -i 's/-lgmp//' ghost++/bncsutil/src/bncsutil/Makefile
 
 # 6) Build bncsutil using the MinGW cross‐compiler
 RUN cd ghost++/bncsutil/src/bncsutil \
-    && make CC=x86_64-w64-mingw32-gcc \
-    CXX=x86_64-w64-mingw32-g++
+    && make CC=i686-w64-mingw32-gcc \
+    CXX=i686-w64-mingw32-g++
 
 # 7) Build GHost++ with Boost & MySQL support
 RUN cd ghost++/ghost \
     && make \
-    CC=x86_64-w64-mingw32-gcc \
-    CXX=x86_64-w64-mingw32-g++ \
+    CC=i686-w64-mingw32-gcc \
+    CXX=i686-w64-mingw32-g++ \
     CFLAGS="-I../bncsutil/src -I../StormLib -I${MYSQL_INC}" \
     LFLAGS="-L../bncsutil/src -L${MYSQL_LIB} -lmysql"
 


### PR DESCRIPTION
## Summary
- ensure MinGW tools match the 32‑bit MySQL connector
- use `i686-w64-mingw32` tools when compiling in Docker

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513037a4e0832688368f830959cd03