### PR TITLE
Fix GHost++ Makefile for cross compilation

### DIFF
--- a/ghost++/ghost/Makefile
+++ b/ghost++/ghost/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 SYSTEM = $(shell uname)
-C++ = g++
+CXX ?= g++
 CC = gcc
 DFLAGS = -DGHOST_MYSQL
 OFLAGS = -O3 -g
@@ -36,13 +36,13 @@ PROGS = ./ghost++
 all: $(OBJS) $(COBJS) $(PROGS)
 
 ./ghost++: $(OBJS) $(COBJS)
-	$(C++) -o ./ghost++ $(OBJS) $(COBJS) $(LFLAGS)
+	$(CXX) -o ./ghost++ $(OBJS) $(COBJS) $(LFLAGS)
 
 clean:
 	rm -f $(OBJS) $(COBJS) $(PROGS)
 
 $(OBJS): %.o: %.cpp
-	$(C++) -o $@ $(CFLAGS) -c $<
+	$(CXX) -o $@ $(CFLAGS) -c $<
 
 $(COBJS): %.o: %.c
 	$(CC) -o $@ $(CFLAGS) -c $<


### PR DESCRIPTION
## Summary
- fix ghost++ Makefile to use the `CXX` variable instead of the unusual `C++`
  so the compiler can be overridden for cross compilation

## Testing
- `make -C ghost++/ghost -n` *(fails: uses host g++, but shows expected commands)*

------
https://chatgpt.com/codex/tasks/task_e_68513274f87483269cddd40483f540b7