### PR TITLE
Install mingw cross compilers for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ COPY . .
 # 2) Install Boost & unzip
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    wget unzip libboost-all-dev mingw-w64-tools binutils-mingw-w64-i686 \
+    wget unzip libboost-all-dev \
+    mingw-w64-tools binutils-mingw-w64-i686 \
+    gcc-mingw-w64-i686 g++-mingw-w64-i686 \
     && rm -rf /var/lib/apt/lists/*
 
 # 3) Download the Windows Connector/C ZIP (32-bit) and unpack it,


### PR DESCRIPTION
## Summary
- fix Dockerfile so required MinGW cross compiler tools are installed

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851460fb5fc832697d47cc5d39ce079