### PR TITLE
Fix GHost++ cross compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,8 @@ RUN cd ghost++/ghost \
     && make \
     CC=i686-w64-mingw32-gcc \
     CXX=i686-w64-mingw32-g++ \
-    CFLAGS="-I../bncsutil/src -I../StormLib -I${MYSQL_INC}" \
-    LFLAGS="-L../bncsutil/src -L${MYSQL_LIB} -lmysql"
+    CFLAGS+="-I${MYSQL_INC}" \
+    LFLAGS+="-L${MYSQL_LIB} -lmysql"
 
 #############################
 # Stage 2: Export only the .exe

--- a/ghost++/ghost/includes.h
+++ b/ghost++/ghost/includes.h
@@ -26,7 +26,11 @@
 // standard integer sizes for 64 bit compatibility
 
 #ifdef WIN32
+#ifdef _MSC_VER
 #include "ms_stdint.h"
+#else
+#include <stdint.h>
+#endif
 #else
 #include <stdint.h>
 #endif

--- a/ghost++/ghost/sha1.h
+++ b/ghost++/ghost/sha1.h
@@ -30,7 +30,11 @@
 // standard integer sizes for 64 bit compatibility
 
 #ifdef WIN32
+#ifdef _MSC_VER
 #include "ms_stdint.h"
+#else
+#include <stdint.h>
+#endif
 #else
 #include <stdint.h>
 #endif


### PR DESCRIPTION
## Summary
- correctly detect MSVC-only stdint header
- keep original Makefile flags when building GHost++

## Testing
- `make` *(fails: `mysql.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685149984b2883269231c9e29ec8e8a9