### PR TITLE
Fix Docker build path for boost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN cd ghost++/ghost \
     && make \
     CC=i686-w64-mingw32-gcc \
     CXX=i686-w64-mingw32-g++ \
-    CFLAGS+="-I${MYSQL_INC}" \
+    CFLAGS+="-I${MYSQL_INC} -I/usr/include" \
     LFLAGS+="-L${MYSQL_LIB} -lmysql"
 
 #############################


### PR DESCRIPTION
## Summary
- ensure the Docker build finds Boost headers by adding `/usr/include` to CFLAGS

## Testing
- `apt-get install -y libboost-all-dev`
- `make` (fails earlier without boost, now proceeds)

------
https://chatgpt.com/codex/tasks/task_e_68514e6b37588326be9cbb9e0458202c