### PR TITLE
Fix cross-compiling with mingw

### DIFF
--- a/ghost++/bncsutil/src/bncsutil/Makefile
+++ b/ghost++/bncsutil/src/bncsutil/Makefile
@@ -1,10 +1,10 @@
 SHELL = /bin/sh
 SYSTEM = $(shell uname)
 CXX = g++
-CXXFLAGS = -Wall -O3 -I ../ -Wno-multichar -fPIC
+CXXFLAGS = -Wall -O3 -I ../ -Wno-multichar -fPIC -DMUTIL_LIB_BUILD
 CXXOBJ = bsha1.o cdkeydecoder.o checkrevision.o decodekey.o file.o libinfo.o oldauth.o
 CC = gcc
-CCFLAGS = -Wall -O3 -I ../ -Wno-multichar -fPIC
+CCFLAGS = -Wall -O3 -I ../ -Wno-multichar -fPIC -DMUTIL_LIB_BUILD
 CCOBJ = nls.o pe.o sha1.o stack.o
 
 TARGET = libbncsutil.so

--- a/ghost++/bncsutil/src/bncsutil/mutil_types.h
+++ b/ghost++/bncsutil/src/bncsutil/mutil_types.h
@@ -27,7 +27,11 @@
 #define BNCSUTIL_MUTIL_TYPES_H_INCLUDED
 
 #ifdef WIN32
+#ifdef _MSC_VER
  #include "ms_stdint.h"
+#else
+ #include <stdint.h>
+#endif
 #else
 
 #if defined(_MSC_VER) || (defined(HAVE_STDINT_H) && !HAVE_STDINT_H)


### PR DESCRIPTION
## Summary
- allow building bncsutil with GCC by using `<stdint.h>` when not using MSVC
- ensure bncsutil functions export correctly during cross-builds

## Testing
- `apt-get update`
- `apt-get install -y gcc-mingw-w64-i686 g++-mingw-w64-i686 binutils-mingw-w64-i686 wget unzip libboost-all-dev mingw-w64-tools`
- `make CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++` *(fails: undefined reference to `__gmpz_*`)*

------
https://chatgpt.com/codex/tasks/task_e_68516185d7208326b1677dbebf7962fe