### PR TITLE
Fix cross compile flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN cd ghost++/ghost \
     && make \
     CC=i686-w64-mingw32-gcc \
     CXX=i686-w64-mingw32-g++ \
-    EXTRA_CFLAGS="-I${MYSQL_INC} -I/usr/include" \
+    EXTRA_CFLAGS="-I${MYSQL_INC}" \
     EXTRA_LFLAGS="-L${MYSQL_LIB} -lmysql"
 
 #############################


### PR DESCRIPTION
## Summary
- remove linux header path from the docker build step

## Testing
- `docker` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516400704c8326acf761e359ab5d72