### PR TITLE
Fix boost header path in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN cd ghost++/ghost \
     && make \
     CC=i686-w64-mingw32-gcc \
     CXX=i686-w64-mingw32-g++ \
-    EXTRA_CFLAGS="-I${MYSQL_INC}" \
+    EXTRA_CFLAGS="-I${MYSQL_INC} -I/usr/include" \
     EXTRA_LFLAGS="-L${MYSQL_LIB} -lmysql"
 
 #############################


### PR DESCRIPTION
## Summary
- fix missing Boost headers when cross-compiling by restoring `/usr/include` path

## Testing
- `apt-get update >/dev/null && apt-cache search libboost | head`

------
https://chatgpt.com/codex/tasks/task_e_685168c759a083268132584a1b19febf